### PR TITLE
Fix 'checksum' spelling

### DIFF
--- a/darwin.go
+++ b/darwin.go
@@ -124,7 +124,7 @@ type InvalidChecksumError struct {
 }
 
 func (i InvalidChecksumError) Error() string {
-	return fmt.Sprintf("Invalid cheksum for migration %f", i.Version)
+	return fmt.Sprintf("Invalid checksum for migration %f", i.Version)
 }
 
 // Validate if the database migrations are applied and consistent

--- a/darwin_test.go
+++ b/darwin_test.go
@@ -174,7 +174,7 @@ func Test_RemovedMigrationError_Error(t *testing.T) {
 func Test_InvalidChecksumError_Error(t *testing.T) {
 	err := InvalidChecksumError{Version: 1}
 
-	if err.Error() != fmt.Sprintf("Invalid cheksum for migration %f", 1.0) {
+	if err.Error() != fmt.Sprintf("Invalid checksum for migration %f", 1.0) {
 		t.Error("Must inform when a migration have an invalid checksum")
 	}
 }


### PR DESCRIPTION
Minor typo - just noticed a couple places where "checksum" was misspelled.