### PR TITLE
Update dependency to its canonical name

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+	"github.com/DATA-DOG/go-sqlmock"
 )
 
 func assertPanic(t *testing.T, f func()) {


### PR DESCRIPTION
The author of the DATADOG package has requested users to use the github.com name. This is documented in the module file for the project. This change will allow the module tooling to use the latest version of the package without the need for developers to issue replace calls.